### PR TITLE
Show the full title in the story list

### DIFF
--- a/app/src/main/res/layout/item_stories_list.xml
+++ b/app/src/main/res/layout/item_stories_list.xml
@@ -28,8 +28,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="2"
                     android:textColor="@color/black"
                     android:textSize="@dimen/text_large_title" />
 


### PR DESCRIPTION
Removes the two line restriction on the titles in the story list. This looks a little worse, but it's often hard to know what the story is without the entire title.
